### PR TITLE
SECD-602 Use tags setting for Datadog stats client

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -76,7 +76,11 @@ func (*DatadogStatsComponent) New(_ context.Context, conf *DatadogStatsConfig) (
 	if err != nil {
 		return nil, err
 	}
-	return xstats.New(dogstatsd.NewMaxPacket(writer, conf.FlushInterval, conf.PacketSize)), nil
+	stater := xstats.New(dogstatsd.NewMaxPacket(writer, conf.FlushInterval, conf.PacketSize))
+	if len(conf.Tags) > 0 {
+		stater.AddTags(conf.Tags...)
+	}
+	return stater, nil
 }
 
 // StatsConfig contains all configuration values for creating

--- a/tests/new_test.go
+++ b/tests/new_test.go
@@ -44,7 +44,8 @@ func TestNew(t *testing.T) {
 	source, err := settings.NewEnvSource([]string{
 		"RUNTIME_HTTPSERVER_ADDRESS=localhost:9090",
 		"RUNTIME_LOGGER_OUTPUT=NULL",
-		"RUNTIME_STATS_OUTPUT=NULL",
+		"RUNTIME_STATS_OUTPUT=DATADOG",
+		"RUNTIME_STATS_DATADOG_TAGS=foo:bar key:value",
 		"RUNTIME_CONNSTATE_NEWCOUNTER=newcounter",
 		"RUNTIME_CONNSTATE_ACTIVECOUNTER=activecounter",
 		"RUNTIME_CONNSTATE_CLOSEDCOUNTER=closedcounter",
@@ -77,7 +78,7 @@ func TestNew(t *testing.T) {
 	stat.EXPECT().Count("closedcounter", float64(1)).AnyTimes()
 	stat.EXPECT().Count("newgauge", gomock.Any()).AnyTimes()
 	stat.EXPECT().Count("idlegauge", gomock.Any()).AnyTimes()
-	stat.EXPECT().Count("activegauge", gomock.Any()).AnyTimes()
+	stat.EXPECT().Count("activegauge", gomock.Any(), []string{"foo:bar","key:value"}).AnyTimes()
 
 	exit := make(chan error)
 	go func() {


### PR DESCRIPTION
Implements the previously unused Tags setting of the DatadogStatsComponent.