### PR TITLE
add Expvar component and gauge metrics

### DIFF
--- a/component.go
+++ b/component.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	HTTP      *HTTPConfig
 	ConnState *ConnStateConfig
+	Expvar    *ExpvarConfig
 	Logger    *LoggerConfig
 	Stats     *StatsConfig
 	Signal    *SignalConfig
@@ -30,6 +31,7 @@ func (*Component) Settings() *Config {
 	return &Config{
 		HTTP:      (&HTTPComponent{}).Settings(),
 		ConnState: (&ConnStateComponent{}).Settings(),
+		Expvar:    (&ExpvarComponent{}).Settings(),
 		Logger:    (&LoggerComponent{}).Settings(),
 		Stats:     (&StatsComponent{}).Settings(),
 		Signal:    (&SignalComponent{}).Settings(),
@@ -40,6 +42,7 @@ func (*Component) Settings() *Config {
 func (c *Component) New(ctx context.Context, conf *Config) (*Runtime, error) {
 	log := &LoggerComponent{}
 	connState := &ConnStateComponent{}
+	expv := &ExpvarComponent{}
 	stat := &StatsComponent{}
 	sigs := &SignalComponent{}
 	srv := &HTTPComponent{}
@@ -56,6 +59,10 @@ func (c *Component) New(ctx context.Context, conf *Config) (*Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
+	expvar, err := expv.New(ctx, conf.Expvar)
+	if err != nil {
+		return nil, err
+	}
 	exit, err := sigs.New(ctx, conf.Signal)
 	if err != nil {
 		return nil, err
@@ -69,6 +76,7 @@ func (c *Component) New(ctx context.Context, conf *Config) (*Runtime, error) {
 		Logger:    logger,
 		Stats:     stats,
 		ConnState: cs,
+		Expvar:    expvar,
 		Exit:      exit,
 		Server:    server,
 		Handler:   c.Handler,

--- a/expvar.go
+++ b/expvar.go
@@ -1,0 +1,181 @@
+package runhttp
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"time"
+)
+
+const (
+	statMemstatsAlloc        = "go_expvar.memstats.alloc"
+	statMemstatsFrees        = "go_expvar.memstats.frees"
+	statMemstatsHeapAlloc    = "go_expvar.memstats.heap_alloc"
+	statMemstatsHeapIdle     = "go_expvar.memstats.heap_idle"
+	statMemstatsHeapInuse    = "go_expvar.memstats.heap_inuse"
+	statMemstatsHeapObjects  = "go_expvar.memstats.heap_objects"
+	statMemstatsHeapReleased = "go_expvar.memstats.heap_released"
+	statMemstatsHeapSys      = "go_expvar.memstats.heap_sys"
+	statMemstatsLookups      = "go_expvar.memstats.lookups"
+	statMemstatsMallocs      = "go_expvar.memstats.mallocs"
+	statMemstatsNumGC        = "go_expvar.memstats.num_gc"
+	statMemstatsPauseNS      = "go_expvar.memstats.pause_ns"
+	statMemstatsPauseTotalNS = "go_expvar.memstats.pause_total_ns"
+	statMemstatsTotalAlloc   = "go_expvar.memstats.total_alloc"
+	statGoroutinesExists     = "go_expvar.goroutines.exists"
+	expvarInterval           = 5 * time.Second
+)
+
+// Expvar tracks the memory usage of the Go runtime and collects metrics instrumented from Go’s expvar package
+type Expvar struct {
+	Stat                     Stat
+	MemstatsAllocName        string
+	MemstatsFreesName        string
+	MemstatsHeapAllocName    string
+	MemstatsHeapIdleName     string
+	MemstatsHeapInuseName    string
+	MemstatsHeapObjectsName  string
+	MemstatsHeapReleasedName string
+	MemstatsHeapSysName      string
+	MemstatsLookupsName      string
+	MemstatsMallocsName      string
+	MemstatsNumGCName        string
+	MemstatsPauseNSName      string
+	MemstatsPauseTotalNSName string
+	MemstatsTotalAllocName   string
+	GoroutinesExistsName     string
+	Interval                 time.Duration
+	statMut                  *sync.Mutex
+	stopMut                  *sync.Mutex
+	stop                     bool
+}
+
+// Report loops on a time interval and pushes a set of gauge metrics.
+func (e *Expvar) Report() {
+	ticker := time.NewTicker(e.Interval)
+	defer ticker.Stop()
+	for range ticker.C {
+		e.report()
+		e.stopMut.Lock()
+		if e.stop {
+			e.stopMut.Unlock()
+			return
+		}
+		e.stopMut.Unlock()
+	}
+}
+
+// Close the reporting loop.
+func (e *Expvar) Close() {
+	e.stopMut.Lock()
+	defer e.stopMut.Unlock()
+	e.stop = true
+}
+
+func (e *Expvar) report() {
+	memstats := new(runtime.MemStats)
+	runtime.ReadMemStats(memstats)
+	numGoroutines := runtime.NumGoroutine()
+
+	e.statMut.Lock()
+	defer e.statMut.Unlock()
+
+	e.Stat.Gauge(e.MemstatsAllocName, float64(memstats.Alloc))
+	e.Stat.Gauge(e.MemstatsFreesName, float64(memstats.Frees))
+	e.Stat.Gauge(e.MemstatsHeapAllocName, float64(memstats.HeapAlloc))
+	e.Stat.Gauge(e.MemstatsHeapIdleName, float64(memstats.HeapIdle))
+	e.Stat.Gauge(e.MemstatsHeapInuseName, float64(memstats.HeapInuse))
+	e.Stat.Gauge(e.MemstatsHeapObjectsName, float64(memstats.HeapObjects))
+	e.Stat.Gauge(e.MemstatsHeapReleasedName, float64(memstats.HeapReleased))
+	e.Stat.Gauge(e.MemstatsHeapSysName, float64(memstats.HeapSys))
+	e.Stat.Gauge(e.MemstatsLookupsName, float64(memstats.Lookups))
+	e.Stat.Gauge(e.MemstatsMallocsName, float64(memstats.Mallocs))
+	e.Stat.Gauge(e.MemstatsNumGCName, float64(memstats.NumGC))
+	e.Stat.Gauge(e.MemstatsPauseTotalNSName, float64(memstats.PauseTotalNs))
+	e.Stat.Gauge(e.MemstatsTotalAllocName, float64(memstats.TotalAlloc))
+	e.Stat.Gauge(e.GoroutinesExistsName, float64(numGoroutines))
+
+	// TODO PauseNS
+}
+
+// ExpvarConfig is a container for internal expvar metrics settings.
+type ExpvarConfig struct {
+	Alloc            string        `description:"Name of the metric tracking allocated bytes"`
+	Frees            string        `description:"Name of the metric tracking number of frees"`
+	HeapAlloc        string        `description:"Name of the metric tracking allocated bytes"`
+	HeapIdle         string        `description:"Name of the metric tracking bytes in unused spans"`
+	HeapInuse        string        `description:"Name of the metric tracking bytes in in-use spans"`
+	HeapObjects      string        `description:"Name of the metric tracking total number of object allocated"`
+	HeapReleased     string        `description:"Name of the metric tracking bytes realeased to the OS"`
+	HeapSys          string        `description:"Name of the metric tracking bytes obtained from the system"`
+	Lookups          string        `description:"Name of the metric tracking number of pointer lookups"`
+	Mallocs          string        `description:"Name of the metric tracking number of mallocs"`
+	NumGC            string        `description:"Name of the metric tracking number of garbage collections"`
+	PauseNS          string        `description:"Name of the metric tracking duration of GC pauses"`
+	PauseTotalNS     string        `description:"Name of the metric tracking total GC pause duration over lifetime process"`
+	TotalAlloc       string        `description:"Name of the metric tracking allocated bytes (even if freed)"`
+	GoroutinesExists string        `description:"Name of the metric tracking number of active go routines"`
+	ReportInterval   time.Duration `description:"Interval on which metrics are reported."`
+}
+
+// Name of the configuration root.
+func (*ExpvarConfig) Name() string {
+	return "expvar"
+}
+
+// Description returns the help information for the configuration root.
+func (*ExpvarConfig) Description() string {
+	return "Expvar metric names."
+}
+
+// ExpvarComponent implements the settings.Component interface for expvar metrics.
+type ExpvarComponent struct{}
+
+// Settings returns a configuration with all defaults set.
+func (*ExpvarComponent) Settings() *ExpvarConfig {
+	return &ExpvarConfig{
+		Alloc:            statMemstatsAlloc,
+		Frees:            statMemstatsFrees,
+		HeapAlloc:        statMemstatsHeapAlloc,
+		HeapIdle:         statMemstatsHeapIdle,
+		HeapInuse:        statMemstatsHeapInuse,
+		HeapObjects:      statMemstatsHeapObjects,
+		HeapReleased:     statMemstatsHeapReleased,
+		HeapSys:          statMemstatsHeapSys,
+		Lookups:          statMemstatsLookups,
+		Mallocs:          statMemstatsMallocs,
+		NumGC:            statMemstatsNumGC,
+		PauseNS:          statMemstatsPauseNS,
+		PauseTotalNS:     statMemstatsPauseTotalNS,
+		TotalAlloc:       statMemstatsTotalAlloc,
+		GoroutinesExists: statGoroutinesExists,
+		ReportInterval:   expvarInterval,
+	}
+}
+
+// New produces a ServerFn bound to the given configuration.
+func (*ExpvarComponent) New(_ context.Context, conf *ExpvarConfig) (func() *Expvar, error) {
+	return func() *Expvar {
+		return &Expvar{
+			MemstatsAllocName:        conf.Alloc,
+			MemstatsFreesName:        conf.Frees,
+			MemstatsHeapAllocName:    conf.HeapAlloc,
+			MemstatsHeapIdleName:     conf.HeapIdle,
+			MemstatsHeapInuseName:    conf.HeapInuse,
+			MemstatsHeapObjectsName:  conf.HeapObjects,
+			MemstatsHeapReleasedName: conf.HeapReleased,
+			MemstatsHeapSysName:      conf.HeapSys,
+			MemstatsLookupsName:      conf.Lookups,
+			MemstatsMallocsName:      conf.Mallocs,
+			MemstatsNumGCName:        conf.NumGC,
+			MemstatsPauseNSName:      conf.PauseNS,
+			MemstatsPauseTotalNSName: conf.PauseTotalNS,
+			MemstatsTotalAllocName:   conf.TotalAlloc,
+			GoroutinesExistsName:     conf.GoroutinesExists,
+			Interval:                 conf.ReportInterval,
+			statMut:                  &sync.Mutex{},
+			stopMut:                  &sync.Mutex{},
+		}
+	}, nil
+
+}

--- a/expvar_test.go
+++ b/expvar_test.go
@@ -1,0 +1,154 @@
+package runhttp
+
+import (
+	"context"
+	"math/rand"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigName(t *testing.T) {
+	assert.Equal(t, "expvar", (&ExpvarConfig{}).Name())
+}
+
+func TestConfigDescription(t *testing.T) {
+	assert.Equal(t, "Expvar metric names", (&ExpvarConfig{}).Description())
+}
+
+func TestReport(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
+	ms := &runtime.MemStats{
+		Alloc:        randGen.Uint64(),
+		Frees:        randGen.Uint64(),
+		HeapAlloc:    randGen.Uint64(),
+		HeapIdle:     randGen.Uint64(),
+		HeapInuse:    randGen.Uint64(),
+		HeapObjects:  randGen.Uint64(),
+		HeapReleased: randGen.Uint64(),
+		HeapSys:      randGen.Uint64(),
+		Lookups:      randGen.Uint64(),
+		Mallocs:      randGen.Uint64(),
+		NumGC:        randGen.Uint32(),
+		PauseTotalNs: randGen.Uint64(),
+		TotalAlloc:   randGen.Uint64(),
+	}
+
+	routines := randGen.Int()
+
+	mockStats := NewMockStat(ctrl)
+
+	gomock.InOrder(
+		mockStats.EXPECT().Gauge(statMemstatsAlloc, float64(ms.Alloc)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsFrees, float64(ms.Frees)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsHeapAlloc, float64(ms.HeapAlloc)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsHeapIdle, float64(ms.HeapIdle)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsHeapInuse, float64(ms.HeapInuse)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsHeapObjects, float64(ms.HeapObjects)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsHeapReleased, float64(ms.HeapReleased)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsHeapSys, float64(ms.HeapSys)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsLookups, float64(ms.Lookups)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsMallocs, float64(ms.Mallocs)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsNumGC, float64(ms.NumGC)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsPauseTotalNS, float64(ms.PauseTotalNs)).Times(1),
+		mockStats.EXPECT().Gauge(statMemstatsTotalAlloc, float64(ms.TotalAlloc)).Times(1),
+		mockStats.EXPECT().Gauge(statGoroutinesExists, float64(routines)).Times(1),
+	)
+
+	expvar := newExpvar(t, fakeReadMemstats(ms), fakeNumGoroutine(routines))
+	expvar.Stat = mockStats
+	expvar.lastNumGC = ms.NumGC // do not collect pauseGC
+	expvar.report()
+}
+
+func TestPauseGC(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pauseNS := [256]uint64{}
+	for i := 0; i < 256; i++ {
+		pauseNS[i] = uint64(i)
+	}
+
+	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
+	ms := &runtime.MemStats{
+		NumGC:   uint32(randGen.Int()),
+		PauseNs: pauseNS,
+	}
+
+	routines := randGen.Int()
+
+	mockStats := NewMockStat(ctrl)
+
+	mockStats.EXPECT().Gauge(gomock.Any(), gomock.Any()).AnyTimes()
+	mockStats.EXPECT().Histogram(statMemstatsPauseNS, gomock.Any()).Times(int((ms.NumGC+255)%256) + 1)
+
+	expvar := newExpvar(t, fakeReadMemstats(ms), fakeNumGoroutine(routines))
+	expvar.Stat = mockStats
+	expvar.report()
+}
+
+func TestPauseGCWithWrap(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pauseNS := [256]uint64{}
+	for i := 0; i < 256; i++ {
+		pauseNS[i] = uint64(i)
+	}
+
+	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
+	ms := &runtime.MemStats{
+		NumGC:   uint32(randGen.Int()),
+		PauseNs: pauseNS,
+	}
+
+	routines := randGen.Int()
+
+	mockStats := NewMockStat(ctrl)
+
+	mockStats.EXPECT().Gauge(gomock.Any(), gomock.Any()).AnyTimes()
+	mockStats.EXPECT().Histogram(statMemstatsPauseNS, gomock.Any()).Times(int((ms.NumGC+255)%256) + 2)
+
+	expvar := newExpvar(t, fakeReadMemstats(ms), fakeNumGoroutine(routines))
+	expvar.Stat = mockStats
+	expvar.lastNumGC = 255
+	expvar.report()
+}
+
+func newExpvar(t *testing.T, fakeReadMemStats func(*runtime.MemStats), fakeNumGoroutine func() int) *Expvar {
+	c := &ExpvarComponent{}
+	expvarFn, err := c.New(context.Background(), c.Settings())
+	require.NoError(t, err)
+	expvar := expvarFn()
+	expvar.numGoroutine = fakeNumGoroutine
+	expvar.readMemStats = fakeReadMemStats
+	return expvar
+}
+
+func fakeNumGoroutine(n int) func() int {
+	return func() int {
+		return n
+	}
+}
+
+func fakeReadMemstats(ms *runtime.MemStats) func(*runtime.MemStats) {
+	return func(ms2 *runtime.MemStats) {
+		src := reflect.Indirect(reflect.ValueOf(ms))
+		dst := reflect.ValueOf(ms2).Elem()
+		for i := 0; i < src.NumField(); i++ {
+			dstField := dst.Field(i)
+			if dstField.CanSet() {
+				dstField.Set(reflect.ValueOf(src.Field(i).Interface()))
+			}
+		}
+	}
+}

--- a/reporter.go
+++ b/reporter.go
@@ -1,0 +1,24 @@
+package runhttp
+
+// Reporter manages a background task which reports metrics outside of the main process
+type Reporter interface {
+	Report()
+	Close()
+}
+
+// MultiReporter manages multiple reporters
+type MultiReporter []Reporter
+
+// Report executes the Report function for all Reporters managed by the MultiReporter
+func (mr MultiReporter) Report() {
+	for _, r := range mr {
+		go r.Report()
+	}
+}
+
+// Close executes the Close function for all Reporters managed by the MultiReporter
+func (mr MultiReporter) Close() {
+	for _, r := range mr {
+		r.Close()
+	}
+}


### PR DESCRIPTION
Our runtime needs to be able to push the go expvar metrics. 

https://docs.datadoghq.com/integrations/go_expvar/#metrics

It is largely based on the ConnState component and [this](https://github.com/DataDog/integrations-core/blob/7d65e7168d85948cce6aa17cb3323a76a32e772b/go_expvar/datadog_checks/go_expvar/go_expvar.py) repo.

Something else to note is that the `ReadMemStats` is a STW process. I am not too informed on how the built-in expvar handler addressed this, but I am slightly concerned that a too frequent interval may be very expensive.